### PR TITLE
fix: editTexts for amount only takes numbers

### DIFF
--- a/app/src/main/res/layout/insert_data.xml
+++ b/app/src/main/res/layout/insert_data.xml
@@ -80,7 +80,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/height_50"
                     android:layout_margin="@dimen/margin_45"
-                    android:hint="@string/enter_money_donated" />
+                    android:hint="@string/enter_money_donated"
+                    android:inputType="number"/>
 
                 <Spinner
                     android:id="@+id/spinner1"
@@ -112,7 +113,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:layout_margin="45dp"
-                    android:hint="amount" />
+                    android:hint="amount"
+                    android:inputType="number"/>
 
                 <android.support.v7.widget.AppCompatCheckBox
                     android:id="@+id/paid_check"

--- a/app/src/main/res/layout/update_data.xml
+++ b/app/src/main/res/layout/update_data.xml
@@ -80,7 +80,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/height_50"
                     android:layout_margin="@dimen/margin_45"
-                    android:hint="@string/enter_money_donated" />
+                    android:hint="@string/enter_money_donated"
+                    android:inputType="number"/>
 
 
                 <Spinner
@@ -106,7 +107,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:layout_margin="45dp"
-                    android:hint="amount" />
+                    android:hint="amount"
+                    android:inputType="number"/>
 
                 <EditText
                     android:id="@+id/name"


### PR DESCRIPTION
Fixed #81 
Changes:editTexts for amount only takes number as input.


Screenshots of the change: 
![Webp net-resizeimage (2)](https://user-images.githubusercontent.com/44549809/60985863-e91f3a00-a35b-11e9-8227-bc50b25b2673.jpg)
