### PR TITLE
fix: Removed non functioning edit texts

### DIFF
--- a/app/src/main/java/org/amfoss/templeapp/activities/InsertData.java
+++ b/app/src/main/java/org/amfoss/templeapp/activities/InsertData.java
@@ -79,6 +79,8 @@ public class InsertData extends AppCompatActivity {
                     insertDataBinding.totalView.setVisibility(View.VISIBLE);
                     insertDataBinding.spinner1.setVisibility(View.GONE);
                     insertDataBinding.moneyDonated.setVisibility(View.VISIBLE);
+                    insertDataBinding.custompooja.setVisibility(View.GONE);
+                    insertDataBinding.amount.setVisibility(View.GONE);
                     id = getResources().getString(R.string.DON);
                     flag = 0;
                     Toast.makeText(getBaseContext(), getString(R.string.selected_donate), Toast.LENGTH_LONG)


### PR DESCRIPTION
Fixed #75 
Changes: The `customPooja` and `amount` editText is now hidden when donations are made.
Screenshots of the change: 
![Webp net-resizeimage (3)](https://user-images.githubusercontent.com/44549809/60996989-5ee2d000-a373-11e9-957e-a472a1c82006.jpg)