### PR TITLE
fix: Edit text for Amount remains even after multiple changes in activities.

### DIFF
--- a/app/src/main/java/org/amfoss/templeapp/activities/InsertData.java
+++ b/app/src/main/java/org/amfoss/templeapp/activities/InsertData.java
@@ -91,6 +91,7 @@ public class InsertData extends AppCompatActivity {
                     insertDataBinding.totalView.setVisibility(View.VISIBLE);
                     insertDataBinding.moneyDonated.setVisibility(View.GONE);
                     insertDataBinding.spinner1.setVisibility(View.VISIBLE);
+                    insertDataBinding.amount.setVisibility(View.VISIBLE);
                     id = getString(R.string.REG);
                     flag = 1;
                     Toast.makeText(


### PR DESCRIPTION
Fixed #98 
Edit text for Amount remains even after multiple changes in activities.